### PR TITLE
feat: implement user sign-up function with pending TODOs (#2)

### DIFF
--- a/src/main/kotlin/com/liftlight/user/application/commands/UserSignUpService.kt
+++ b/src/main/kotlin/com/liftlight/user/application/commands/UserSignUpService.kt
@@ -1,0 +1,28 @@
+package com.liftlight.user.application.commands
+
+import com.liftlight.user.model.entities.UserEntity
+import com.liftlight.user.presentation.request.UserSignUpRequest
+import com.liftlight.user.repositories.UserRepository
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class UserSignUpService( // TODO: BCryptPasswordEncoder 빈 등록
+    private val userRepository: UserRepository,
+    private val passwordEncoder: BCryptPasswordEncoder
+) {
+
+    fun registerUser(userSignUpRequest: UserSignUpRequest): UserEntity {
+        userRepository.findByEmail(userSignUpRequest.email).ifPresent {
+            // TODO: CustomException 생성
+            throw CustomException(userSignUpRequest.email)
+        }
+
+        val encodedPassword = passwordEncoder.encode(userSignUpRequest.password)
+        val userEntity = UserEntity.fromRequestAndPassword(
+            userSignUpRequest,
+            encodedPassword
+        )
+        return userRepository.save(userEntity)
+    }
+}

--- a/src/main/kotlin/com/liftlight/user/enums/Country.kt
+++ b/src/main/kotlin/com/liftlight/user/enums/Country.kt
@@ -1,0 +1,7 @@
+package com.liftlight.user.enums
+
+enum class Country {
+    USA,
+    CANADA,
+    KOREA
+}

--- a/src/main/kotlin/com/liftlight/user/enums/UserRole.kt
+++ b/src/main/kotlin/com/liftlight/user/enums/UserRole.kt
@@ -1,0 +1,9 @@
+package com.liftlight.user.enums
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+enum class UserRole(val roleName: String, val authorities: List<GrantedAuthority>) {
+    ROLE_USER("ROLE_USER", listOf(SimpleGrantedAuthority("ROLE_USER"))),
+    ROLE_ADMIN("ROLE_ADMIN", listOf(SimpleGrantedAuthority("ROLE_ADMIN")));
+}

--- a/src/main/kotlin/com/liftlight/user/enums/UserStatus.kt
+++ b/src/main/kotlin/com/liftlight/user/enums/UserStatus.kt
@@ -1,0 +1,8 @@
+package com.liftlight.user.enums
+
+enum class UserStatus() {
+    PENDING,
+    ACTIVE,
+    INACTIVE,
+    DELETED
+}

--- a/src/main/kotlin/com/liftlight/user/model/dtos/UserDTO.kt
+++ b/src/main/kotlin/com/liftlight/user/model/dtos/UserDTO.kt
@@ -1,0 +1,32 @@
+package com.liftlight.user.model.dtos
+
+import com.liftlight.user.enums.Country
+import com.liftlight.user.model.entities.UserEntity
+
+data class UserDTO(
+    var id: Long,
+    var nickName: String,
+    var email: String,
+    var rank: Long,
+    var point: Long,
+    var squat: Long,
+    var benchPress: Long,
+    var deadLift: Long,
+    var country: Country,
+    var profileImageUrl: String
+)
+
+fun UserEntity.toDTO(): UserDTO {
+    return UserDTO(
+        id = this.id ?: 0L,
+        nickName = this.nickName,
+        email = this.email,
+        rank = this.rank,
+        point = this.point,
+        squat = this.squat,
+        benchPress = this.benchPress,
+        deadLift = this.deadLift,
+        country = this.country,
+        profileImageUrl = this.profileImageUrl
+    )
+}

--- a/src/main/kotlin/com/liftlight/user/model/entities/UserEntity.kt
+++ b/src/main/kotlin/com/liftlight/user/model/entities/UserEntity.kt
@@ -1,0 +1,58 @@
+package com.liftlight.user.model.entities
+
+import com.liftlight.infrastructure.BaseEntity
+import com.liftlight.user.enums.Country
+import com.liftlight.user.enums.UserRole
+import com.liftlight.user.enums.UserStatus
+import com.liftlight.user.presentation.request.UserSignUpRequest
+import jakarta.persistence.*
+
+@Entity
+class UserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    var nickName: String,
+    var email: String,
+    var password: String,
+
+    @Enumerated(EnumType.STRING)
+    var role: UserRole,
+
+    @Enumerated(EnumType.STRING)
+    var status: UserStatus,
+
+    var rank: Long = 0,
+    var squat: Long = 0,
+    var point: Long = 0,
+    var benchPress: Long = 0,
+    var deadLift: Long = 0,
+
+    @Enumerated(EnumType.STRING)
+    var country: Country,
+
+    var profileImageUrl: String
+) : BaseEntity() {
+    companion object {
+        fun fromRequestAndPassword(
+            userSignUpRequest: UserSignUpRequest,
+            password: String
+        ): UserEntity {
+            return UserEntity(
+                nickName = userSignUpRequest.nickName,
+                email = userSignUpRequest.email,
+                password = password,
+                role = UserRole.ROLE_USER,
+                status = UserStatus.PENDING,
+                rank = 0,
+                point = 0,
+                squat = 0,
+                benchPress = 0,
+                deadLift = 0,
+                country = userSignUpRequest.country,
+                profileImageUrl = userSignUpRequest.profileImageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/liftlight/user/presentation/controller/UserController.kt
+++ b/src/main/kotlin/com/liftlight/user/presentation/controller/UserController.kt
@@ -1,0 +1,24 @@
+package com.liftlight.user.presentation.controller
+
+import com.liftlight.user.application.commands.UserSignUpService
+import com.liftlight.user.presentation.request.UserSignUpRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(@Autowired val userSignUpService: UserSignUpService) {
+
+    @PostMapping("/register")
+    fun registerUser(
+        @RequestBody userSignUpRequest: UserSignUpRequest,
+    ): ResponseEntity<Void> {
+        userSignUpService.registerUser(userSignUpRequest)
+        return ResponseEntity.status(CREATED).build()
+    }
+}

--- a/src/main/kotlin/com/liftlight/user/presentation/request/UserSignUpRequest.kt
+++ b/src/main/kotlin/com/liftlight/user/presentation/request/UserSignUpRequest.kt
@@ -1,0 +1,12 @@
+package com.liftlight.user.presentation.request
+
+import com.liftlight.user.enums.Country
+
+data class UserSignUpRequest(
+    var id: Long,
+    var nickName: String,
+    var email: String,
+    var password: String,
+    var country: Country,
+    var profileImageUrl: String
+)

--- a/src/main/kotlin/com/liftlight/user/repositories/UserRepository.kt
+++ b/src/main/kotlin/com/liftlight/user/repositories/UserRepository.kt
@@ -1,0 +1,11 @@
+package com.liftlight.user.repositories
+
+import com.liftlight.user.model.entities.UserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface UserRepository : JpaRepository<UserEntity, Long> {
+    fun findByEmail(email: String): Optional<UserEntity>
+}


### PR DESCRIPTION
### Description

- implement user sign-up function with pending TODOs

### Changes (Added sections)

- Added UserController with sign-up endpoint
- Added UserService for handling user sign-up logic
- Added UserRepository for database interactions
- Integrated password encryption using BCryptPasswordEncoder
- Added validation for duplicate email addresses

### Special Notes
- Implementation needed for jwtTokenProvider.getAccountFromToken(String token)
- Unit tests for sign-up logic are pending
- Exception handling for edge cases needs to be added
- Email verification process to be implemented

### Testing

- [ ] Test Code
- [ ] API Test