### PR TITLE
feat: add error codes for user sign-in status (#11)

### DIFF
--- a/src/main/kotlin/com/liftlight/infrastructure/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/liftlight/infrastructure/exception/ErrorCode.kt
@@ -1,7 +1,14 @@
 package com.liftlight.infrastructure.exception
 
-enum class ErrorCode(val code: String, val message: String) {
-    UNDEFINED_EXCEPTION("UNDEFINED_EXCEPTION", "알 수 없는 오류가 발생했습니다."),
-    USER_ALREADY_EXISTS("USER_ALREADY_EXISTS", "이미 존재하는 사용자입니다."),
-    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.")
+import jakarta.xml.ws.http.HTTPException
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.*
+
+enum class ErrorCode(val code: HttpStatus, val message: String) {
+    UNDEFINED_EXCEPTION(INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
+    USER_ALREADY_EXISTS(BAD_REQUEST, "이미 존재하는 사용자입니다."),
+    USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_NOT_VERIFIED(BAD_REQUEST, "사용자가 인증되지 않았습니다."),
+    DELETED_USER(BAD_REQUEST, "삭제된 사용자입니다."),
+    INACTIVE_USER(BAD_REQUEST, "비활성화된 사용자입니다."),
 }


### PR DESCRIPTION
### Description

- add error codes for user sign-in status

### Changes (Added sections)

- validate user status during sign-in; throw errors if not active.
### Special Notes

- none

### Testing

- [x] Test Code
- [x] API Test
 